### PR TITLE
Bump logback-classic from 1.0.13 to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.0.13</version>
+			<version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.serenity-bdd</groupId>


### PR DESCRIPTION
Bumps logback-classic from 1.0.13 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>